### PR TITLE
regexp + cosmetics

### DIFF
--- a/PyCrawler.py
+++ b/PyCrawler.py
@@ -51,7 +51,7 @@ connection.commit()
 
 # Compile keyword and link regex expressions
 keywordregex = re.compile('<meta\sname=["\']keywords["\']\scontent=["\'](.*?)["\']\s/>')
-linkregex = re.compile('<a\s*href=[\'|"](.*?)[\'"].*?>')
+linkregex = re.compile('<a.*\shref=[\'"](.*?)[\'"].*?>')
 crawled = []
 
 # set crawling status and stick starting url into the queue


### PR DESCRIPTION
The new regexp allows for other attributes between a-tag start and href attribute, and doesn't allow | character as attribute value begin delimiter (' " are fine).

Nice code, does the job well, thanks!
