### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Logging
 =======
 - DEBUG+ level messages are logged to the console, and INFO+ level messages are logged to a file.
 - By default, the file for logging uses a TimedRotatingFileHandler that rolls over at midnight
-- Setting DEBUG in the settings toggles wether or not DEBUG level messages are output at all
+- Setting DEBUG in the settings toggles whether or not DEBUG level messages are output at all
 - Setting USE_COLORS in the settings toggles whether or not messages output to the console use colors depending on the level.
 
 Misc
 ====
 - Designed to be able to run on multiple machines and work together to collect info in central DB
 - Queues links into the database to be crawled. This means that any machine running the crawler with the central db can grab from the same queue. Reduces crawling redundancy.
-- Thread pool apprach to analyzing keywords in text.
+- Thread pool approach to analyzing keywords in text.


### PR DESCRIPTION
There are small typos in:
- README.md

Fixes:
- Should read `whether` rather than `wether`.
- Should read `approach` rather than `apprach`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md